### PR TITLE
Use relative paths for fonts

### DIFF
--- a/bootstrap-sass-styles.loader.js
+++ b/bootstrap-sass-styles.loader.js
@@ -54,9 +54,10 @@ module.exports = function (content) {
   var pathToBootstrapSass = bootstrapSassPath.getPath(this.context);
   logger.verbose(config, "bootstrap-sass location: %s", pathToBootstrapSass);
 
+  var relativePath = path.relative(this.context, pathToBootstrapSass);
   var start =
     "@import          \""+ path.join(pathToBootstrapSass, "stylesheets/bootstrap/variables") + "\";\n" +
-    "$icon-font-path: \""+ path.join(pathToBootstrapSass, "fonts/bootstrap") + "\";\n";
+    "$icon-font-path: \""+ path.join(relativePath, "fonts/bootstrap/") + "\";\n";
 
   if (bootstrapCustomizations && fs.existsSync(bootstrapCustomizations)) {
     logger.verbose(config, "bootstrapCustomizations: %s", bootstrapCustomizations);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-sass-loader",
   "description": "bootstrap-sass package for webpack",
   "main": "index.js",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "loader": "index.loader.js",
   "keywords": [
     "bootstrap",


### PR DESCRIPTION
Previous code was using an absolute path for the fonts and this was
getting put into the output CSS, resulting in a failure when the style
links to the full path, rather than the relative path.
