### PR TITLE
Add preBootstrapCustomizations configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,11 @@ The disadvantage to using this setup is that you can't:
 ### 1.b Customized Bootstrap
 
 1. Copy the file `bootstrap-sass.config.js` to your project. You will specify the file path in the `require` statement.
-2. Open that file to customize the location of a file for any Boostrap variable overrides, and your main Sass file that
-   might depend on Bootstrap variables. The location of these two files are optional. You may also remove Sass or Js
-   modules that you don't need.
+2. Open that file to customize the location of a file for any Boostrap variable overrides (`preBootstrapCustomizations`
+   and `bootstrapCustomizations`, and your main Sass file that can depend on Bootstrap variables, plus your customizations.
+   Any of these 3 files are optional. You may also remove any Sass or Js modules that you don't need.
 
-Next, you may either require the sass files in a Js file, or you might specify this as an entry point.
-
-```javascript
-require("bootstrap-sass!./path/to/bootstrap-sass.config.js");
-```
+Next, you should specify this as an entry point:
 
 ```
 module.exports = {
@@ -67,6 +63,13 @@ module.exports = {
     "bootstrap-sass!./path/to/bootstrap-sass.config.js"
   ]
 ```
+
+Or a dependency within a file, like you'd specify other webpack dependencies:
+
+```javascript
+require("bootstrap-sass!./path/to/bootstrap-sass.config.js");
+```
+
 
 #### `bootstrap-sass.config.js`
 
@@ -142,7 +145,21 @@ you may have issues.
 # Known Issues
 1. Automatic Dependency loading is currently problematic. If you "touch" either of the customization files listed in
    your config file (bootstrapCustomizations, mainSass), then that will trigger a rebuild of the Sass files. This is a 
-   known issue with the sass-loader.
+   known issue with the sass-loader. I work around this issue by "touching" one of the 3 sass config files.
 
 
+Testing Changes in the Bootstrap Sass Loader
+=======================================================
+1. See this article [Debugging NodeJs and Webpack Loaders](http://forum.railsonmaui.com/t/debugging-nodejs-and-webpack-loaders/142)
+2. Clone both this project and https://github.com/justin808/bootstrap-sass-loader-example
+3. Use the npm link command per step #1 (see article)
 
+Then in the bootstrap-sass-loader-example project:
+
+1. Make some changes in the loader, put in some print statements maybe, then run `gulp webpack` to invoke the loader.
+2. Then run `gulp build`and open the resulting file dist/index.html in the browser.
+
+
+Pull requests are welcome!
+
+For more info see: http://www.railsonmaui.com and http://forum.railsonmaui.com.

--- a/bootstrap-sass-styles.loader.js
+++ b/bootstrap-sass-styles.loader.js
@@ -70,7 +70,11 @@ module.exports = function (content) {
   logger.verbose(config, "bootstrap-sass location: %s", pathToBootstrapSass);
 
   var relativePath = path.relative(this.context, pathToBootstrapSass);
-  var start =
+  var start = "";
+  if (config.preBootstrapCustomizations) {
+    start += addImportReturnDependency(this, config, "preBootstrapCustomizations");
+  }
+  start +=
     "@import          \"" + path.join(pathToBootstrapSass, "stylesheets/bootstrap/variables") + "\";\n" +
     "$icon-font-path: \"" + path.join(relativePath, "fonts/bootstrap/") + "\";\n";
 

--- a/bootstrap-sass.config.js
+++ b/bootstrap-sass.config.js
@@ -1,4 +1,5 @@
-// Example file. Copy this to your project
+// Example file. Copy this to your project. Change then names of the referenced files or comment them out.
+// Convention is to name sass partials to start with an "_"
 module.exports = {
   verbose: true, // Set to true to show diagnostic information
 
@@ -7,8 +8,15 @@ module.exports = {
   // mainSass: gets loaded after bootstrap, so you can override a bootstrap style.
   // NOTE, these are optional.
 
-   bootstrapCustomizations: "./bootstrap-customizations.scss",
-   mainSass: "./main.scss",
+  // Use preBootstrapCustomizations to change $brand-primary. Ensure this preBootstrapCustomizations does not
+  // depend on other bootstrap variables.
+  preBootstrapCustomizations: "./_pre-bootstrap-customizations.scss",
+
+  // Use bootstrapCustomizations to utilize other sass variables defined in preBootstrapCustomizations or the
+  // _variables.scss file. This is useful to set one customization value based on another value.
+  bootstrapCustomizations: "./_bootstrap-customizations.scss",
+
+  mainSass: "./_main.scss",
 
   // Default for the style loading
   styleLoader: "style-loader!css-loader!sass-loader",


### PR DESCRIPTION
* Allows setting variables like $brand-primary that other variables in
  the bootstrap file _variables.scss depend upon.
* Still provides the bootstrapCustomizations configuration option to
  allow defining variables the depend on other bootstrap variables.
* No backwards compatability issues.