### PR TITLE
Fix windows path for @import CSS at-rule

### DIFF
--- a/bootstrap-sass-styles.loader.js
+++ b/bootstrap-sass-styles.loader.js
@@ -96,6 +96,8 @@ module.exports = function (content) {
     source += "\n" + addImportReturnDependency(this, config, "mainSass");
   }
 
+  source = source.replace(/\\/g, '/');
+
   logger.debug(config, "Generated scss file is:\n" + source);
 
   return source;


### PR DESCRIPTION
PR to solve this issue: [justin808/bootstrap-sass-loader#14](https://github.com/justin808/bootstrap-sass-loader/issues/14) 
It was tested on MAC and Win 8.