### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Boostrap Version
 ---
 The version of sass-bootrap used is listed in peerDependencies, so you should be able to use whichever version you like.
 
-Simply specify that version of `sass-bootrap` in your `package.json`, like this:
+Simply specify that version of `bootstrap-sass` in your `package.json`, like this:
 
     "bootstrap-sass": "~3.3.1"
 
@@ -128,11 +128,11 @@ module.exports = {
 
       // Needed for the css-loader when [bootstrap-webpack](https://github.com/bline/bootstrap-webpack)
       // loads bootstrap's css.
-      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,   loader: "url?limit=10000&minetype=application/font-woff" },
-      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,  loader: "url?limit=10000&minetype=application/font-woff" },
-      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,    loader: "url?limit=10000&minetype=application/octet-stream" },
+      { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,   loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,  loader: "url?limit=10000&mimetype=application/font-woff" },
+      { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,    loader: "url?limit=10000&mimetype=application/octet-stream" },
       { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,    loader: "file" },
-      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,    loader: "url?limit=10000&minetype=image/svg+xml" }
+      { test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,    loader: "url?limit=10000&mimetype=image/svg+xml" }
     ]
   }
 };


### PR DESCRIPTION
- Changed `sass-bootstrap` to `bootstrap-sass`
- Change `minetype` to `mimetype` url loader works with `minetype` but this is legacy functionality because of a typo in earlier versions.